### PR TITLE
Open first command line argument by default

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -316,6 +316,13 @@ app.on('ready', function() {
 
   appWindow.once('ready-to-show', function() {
     appWindow.show();
+
+    var argsLength = process.defaultApp ? 3 : 2;
+    if (process.argv.length >= argsLength) {
+      appWindow.webContents.send('openTournament', process.argv[argsLength-1]);
+
+      // console.log(process.argv[argsLength-1]);
+    }
   }); //ready-to-show
 
   /*---------------------------------------------------------


### PR DESCRIPTION
Allows for (manual) setting of file association with right click menus.

Should be made default in windows / osx installers but I don't have either system to test...